### PR TITLE
Adding Status fields to Monocle Resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ tasks:
 - [X] Elastic / API / Crawler deployment support
 - [X] Validate config ConfigMap update
 - [X] Handle secret data update
-- [] Set Monocle Resource Status
+- [x] Set Monocle Resource Status
 - [] Produce and publish the operator container image
 - [] Document operator deployment
 - [] Git config support

--- a/api/v1alpha1/monocle_types.go
+++ b/api/v1alpha1/monocle_types.go
@@ -36,6 +36,9 @@ type MonocleSpec struct {
 type MonocleStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
+	Elastic string `json:"monocle-elastic,omitempty"`
+	Api string `json:"monocle-api,omitempty"`
+	Crawler string `json:"monocle-crawler,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/monocle.monocle.change-metrics.io_monocles.yaml
+++ b/config/crd/bases/monocle.monocle.change-metrics.io_monocles.yaml
@@ -41,6 +41,16 @@ spec:
             type: object
           status:
             description: MonocleStatus defines the observed state of Monocle
+            properties:
+              monocle-api:
+                type: string
+              monocle-crawler:
+                type: string
+              monocle-elastic:
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of cluster Important: Run "make" to regenerate code after modifying
+                  this file'
+                type: string
             type: object
         type: object
     served: true


### PR DESCRIPTION
This change adds 3 new Status fields to the Monocle Resource:
 - API
 - Crawler
 - Elastic

Now the user can check the status of Monocle Resource with: 
kubectl get monocles <monocle-instance-name> -o yaml