### PR TITLE
Monocle operator image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Build the manager binary
-FROM golang:1.19 as builder
+#FROM golang:1.19 as builder
+FROM quay.io/projectquay/golang:1.19 as builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Makefile
+++ b/Makefile
@@ -213,9 +213,17 @@ bundle: manifests kustomize ## Generate bundle manifests and metadata, then vali
 bundle-build: ## Build the bundle image.
 	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
+.PHONY: bundle-container-build
+bundle-container-build: ## Build the bundle image.
+	podman build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+
 .PHONY: bundle-push
 bundle-push: ## Push the bundle image.
 	$(MAKE) docker-push IMG=$(BUNDLE_IMG)
+
+.PHONY: bundle-container-push
+bundle-container-push: ## Push the bundle image.
+	$(MAKE) container-push IMG=$(BUNDLE_IMG)
 
 .PHONY: opm
 OPM = ./bin/opm

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ ifeq ($(USE_IMAGE_DIGESTS), true)
 endif
 
 # Image URL to use all building/pushing image targets
-IMG ?= controller:latest
+IMG ?= controller:v0.13.0
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.25.0
 
@@ -87,7 +87,7 @@ help: ## Display this help.
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) rbac:roleName=controller-manager crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
@@ -121,6 +121,10 @@ run: manifests generate fmt vet ## Run a controller from your host.
 .PHONY: container-build
 container-build: test ## Build docker image with the manager.
 	podman build -t ${IMG} .
+
+.PHONY: container-push
+container-push: ## Push docker image with the manager.
+	podman push ${IMG}
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 #
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
 # monocle.change-metrics.io/monocle-operator-bundle:$VERSION and monocle.change-metrics.io/monocle-operator-catalog:$VERSION.
-IMAGE_TAG_BASE ?= monocle.change-metrics.io/monocle-operator
+IMAGE_TAG_BASE ?= quay.io/change-metrics/monocle-operator
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
@@ -47,7 +47,7 @@ ifeq ($(USE_IMAGE_DIGESTS), true)
 endif
 
 # Image URL to use all building/pushing image targets
-IMG ?= controller:v0.13.0
+IMG ?= quay.io/change-metrics/monocle-operator:v$(VERSION)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.25.0
 
@@ -87,7 +87,7 @@ help: ## Display this help.
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=controller-manager crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -1,0 +1,20 @@
+FROM scratch
+
+# Core bundle labels.
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=monocle-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.27.0
+LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
+LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
+
+# Labels for testing.
+LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
+LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
+
+# Copy files to locations specified by labels.
+COPY bundle/manifests /manifests/
+COPY bundle/metadata /metadata/
+COPY bundle/tests/scorecard /tests/scorecard/

--- a/bundle/manifests/monocle-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle/manifests/monocle-operator-controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: monocle-operator
+    app.kubernetes.io/instance: controller-manager-metrics-service
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: service
+    app.kubernetes.io/part-of: monocle-operator
+    control-plane: controller-manager
+  name: monocle-operator-controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/bundle/manifests/monocle-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/monocle-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: monocle-operator
+    app.kubernetes.io/instance: metrics-reader
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/part-of: monocle-operator
+  name: monocle-operator-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/bundle/manifests/monocle-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/monocle-operator.clusterserviceversion.yaml
@@ -1,0 +1,246 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "monocle.monocle.change-metrics.io/v1alpha1",
+          "kind": "Monocle",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/created-by": "monocle-operator",
+              "app.kubernetes.io/instance": "monocle-sample",
+              "app.kubernetes.io/managed-by": "kustomize",
+              "app.kubernetes.io/name": "monocle",
+              "app.kubernetes.io/part-of": "monocle-operator"
+            },
+            "name": "monocle-sample"
+          },
+          "spec": {}
+        }
+      ]
+    capabilities: Basic Install
+    createdAt: "2023-03-06T11:51:10Z"
+    operators.operatorframework.io/builder: operator-sdk-v1.27.0
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+  name: monocle-operator.v0.0.1
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Monocle is the Schema for the monocles API
+      displayName: Monocle
+      kind: Monocle
+      name: monocles.monocle.monocle.change-metrics.io
+      version: v1alpha1
+  description: Monocle Git Repos Dashboard
+  displayName: Monocle Operator
+  icon:
+  - base64data: ""
+    mediatype: ""
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - secrets
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - deployments
+          - secret
+          - service
+          - statefulset
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - '*'
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: monocle-operator-controller-manager
+      deployments:
+      - label:
+          app.kubernetes.io/component: manager
+          app.kubernetes.io/created-by: monocle-operator
+          app.kubernetes.io/instance: controller-manager
+          app.kubernetes.io/managed-by: kustomize
+          app.kubernetes.io/name: deployment
+          app.kubernetes.io/part-of: monocle-operator
+          control-plane: controller-manager
+        name: monocle-operator-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              control-plane: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                kubectl.kubernetes.io/default-container: manager
+              labels:
+                control-plane: controller-manager
+            spec:
+              affinity:
+                nodeAffinity:
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    nodeSelectorTerms:
+                    - matchExpressions:
+                      - key: kubernetes.io/arch
+                        operator: In
+                        values:
+                        - amd64
+                        - arm64
+                        - ppc64le
+                        - s390x
+                      - key: kubernetes.io/os
+                        operator: In
+                        values:
+                        - linux
+              containers:
+              - args:
+                - --secure-listen-address=0.0.0.0:8443
+                - --upstream=http://127.0.0.1:8080/
+                - --logtostderr=true
+                - --v=0
+                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
+                name: kube-rbac-proxy
+                ports:
+                - containerPort: 8443
+                  name: https
+                  protocol: TCP
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 128Mi
+                  requests:
+                    cpu: 5m
+                    memory: 64Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+              - args:
+                - --health-probe-bind-address=:8081
+                - --metrics-bind-address=127.0.0.1:8080
+                - --leader-elect
+                command:
+                - /manager
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                image: quay.io/rh_ee_fserucas/monocle-operator:0.1
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 128Mi
+                  requests:
+                    cpu: 10m
+                    memory: 64Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: monocle-operator-controller-manager
+              terminationGracePeriodSeconds: 10
+    strategy: deployment
+  installModes:
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - monocle
+  - git
+  - repo
+  - dashboard
+  links:
+  - name: Monocle Operator
+    url: https://monocle-operator.domain
+  maturity: alpha
+  provider:
+    name: MonocleOperator
+    url: https://github.com/change-metrics/monocle
+  version: 0.0.1

--- a/bundle/manifests/monocle.monocle.change-metrics.io_monocles.yaml
+++ b/bundle/manifests/monocle.monocle.change-metrics.io_monocles.yaml
@@ -1,0 +1,64 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  name: monocles.monocle.monocle.change-metrics.io
+spec:
+  group: monocle.monocle.change-metrics.io
+  names:
+    kind: Monocle
+    listKind: MonocleList
+    plural: monocles
+    singular: monocle
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Monocle is the Schema for the monocles API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MonocleSpec defines the desired state of Monocle
+            properties:
+              monoclePublicURL:
+                default: https://localhost:8090
+                type: string
+            type: object
+          status:
+            description: MonocleStatus defines the observed state of Monocle
+            properties:
+              monocle-api:
+                type: string
+              monocle-crawler:
+                type: string
+              monocle-elastic:
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of cluster Important: Run "make" to regenerate code after modifying
+                  this file'
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -1,0 +1,14 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: monocle-operator
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.27.0
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/

--- a/bundle/tests/scorecard/config.yaml
+++ b/bundle/tests/scorecard/config.yaml
@@ -1,0 +1,70 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests:
+  - entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:v1.26.0
+    labels:
+      suite: basic
+      test: basic-check-spec-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:v1.26.0
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:v1.26.0
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-resources
+    image: quay.io/operator-framework/scorecard-test:v1.26.0
+    labels:
+      suite: olm
+      test: olm-crds-have-resources-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.26.0
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-status-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.26.0
+    labels:
+      suite: olm
+      test: olm-status-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+storage:
+  spec:
+    mountPath: {}

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: controller
-  newTag: latest
+  newName: quay.io/rh_ee_fserucas/monocle-operator
+  newTag: "0.1"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -70,7 +70,7 @@ spec:
             - /manager
           args:
             - --leader-elect
-          image: controller:latest
+          image: controller:v0.13.0
           name: manager
           securityContext:
             allowPrivilegeEscalation: false

--- a/config/manifests/bases/monocle-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/monocle-operator.clusterserviceversion.yaml
@@ -1,0 +1,48 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: '[]'
+    capabilities: Basic Install
+  name: monocle-operator.v0.0.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Monocle is the Schema for the monocles API
+      displayName: Monocle
+      kind: Monocle
+      name: monocles.monocle.monocle.change-metrics.io
+      version: v1alpha1
+  description: Monocle Git Repos Dashboard
+  displayName: Monocle Operator
+  icon:
+  - base64data: ""
+    mediatype: ""
+  install:
+    spec:
+      deployments: null
+    strategy: ""
+  installModes:
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - monocle
+  - git
+  - repo
+  - dashboard
+  links:
+  - name: Monocle Operator
+    url: https://monocle-operator.domain
+  maturity: alpha
+  provider:
+    name: MonocleOperator
+    url: https://github.com/change-metrics/monocle
+  version: 0.0.0

--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -1,9 +1,9 @@
 # permissions to do leader election.
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/name: role
+    app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: leader-election-role
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: monocle-operator
@@ -15,6 +15,8 @@ rules:
   - ""
   resources:
   - configmaps
+  - secrets
+  - services
   verbs:
   - get
   - list

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -1,8 +1,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: rolebinding
+    app.kubernetes.io/name: clusterrolebinding
     app.kubernetes.io/instance: leader-election-rolebinding
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: monocle-operator
@@ -11,7 +11,7 @@ metadata:
   name: leader-election-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: leader-election-role
 subjects:
 - kind: ServiceAccount

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: controller-manager
+  name: manager-role
 rules:
 - apiGroups:
   - apps

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,33 +1,34 @@
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: controller-manager
 rules:
-  - apiGroups:
-      - monocle.monocle.change-metrics.io
-    resources:
-      - monocles
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - monocle.monocle.change-metrics.io
-    resources:
-      - monocles/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - monocle.monocle.change-metrics.io
-    resources:
-      - monocles/status
-    verbs:
-      - get
-      - patch
-      - update
+- apiGroups:
+  - ""
+  resources:
+  - deployments
+  - secret
+  - service
+  - statefulset
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -6,24 +6,15 @@ metadata:
   name: controller-manager
 rules:
 - apiGroups:
-  - ""
+  - apps
+  - monocle.monocle.change-metrics.io
+  - v1
   resources:
   - deployments
-  - secret
-  - service
-  - statefulset
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - '*'
-  resources:
-  - '*'
+  - monocles
+  - secrets
+  - services
+  - statefulsets
   verbs:
   - create
   - delete

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   creationTimestamp: null
-  name: manager-role
+  name: controller-manager
 rules:
   - apiGroups:
       - monocle.monocle.change-metrics.io

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -1,8 +1,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/name: rolebinding
     app.kubernetes.io/instance: manager-rolebinding
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: monocle-operator
@@ -12,7 +12,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: controller-manager
+  name: manager-role
 subjects:
   - kind: ServiceAccount
     name: controller-manager

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/name: rolebinding
     app.kubernetes.io/instance: manager-rolebinding
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: monocle-operator
@@ -12,7 +12,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: manager-role
+  name: controller-manager
 subjects:
   - kind: ServiceAccount
     name: controller-manager

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -1,8 +1,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: rolebinding
+    app.kubernetes.io/name: clusterrolebinding
     app.kubernetes.io/instance: manager-rolebinding
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: monocle-operator

--- a/controllers/monocle_controller.go
+++ b/controllers/monocle_controller.go
@@ -40,6 +40,9 @@ import (
 	"github.com/thanhpk/randstr"
 )
 
+//+kubebuilder:rbac:groups="",resources=deployments;secret;statefulset;service,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="*",resources="*",verbs=get;list;watch;create;update;patch;delete
+
 // MonocleReconciler reconciles a Monocle object
 type MonocleReconciler struct {
 	client.Client

--- a/controllers/monocle_controller.go
+++ b/controllers/monocle_controller.go
@@ -40,8 +40,8 @@ import (
 	"github.com/thanhpk/randstr"
 )
 
-//+kubebuilder:rbac:groups="",resources=deployments;secret;statefulset;service,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups="*",resources="*",verbs=get;list;watch;create;update;patch;delete
+// The order of groups metters. apps -> v1 -> monocle.monocle.change-metrics.io
+//+kubebuilder:rbac:groups=apps;v1;monocle.monocle.change-metrics.io,resources=monocles;deployments;secrets;statefulsets;services,verbs=get;list;watch;create;update;patch;delete
 
 // MonocleReconciler reconciles a Monocle object
 type MonocleReconciler struct {


### PR DESCRIPTION
This Change introduces the following changes:

Adds new Makefile instructions to generate bundle operator using podman.
Changes RBAC files to make Monocle Operator work ClusterWide.
Add Operator bundle files.
